### PR TITLE
Update 4_Capabilities.sh: Fix capability decoding to prevent shell from displaying excessive number sequence

### DIFF
--- a/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh
+++ b/linPEAS/builder/linpeas_parts/8_interesting_perms_files/4_Capabilities.sh
@@ -11,33 +11,59 @@
 # Generated Global Variables: $cap_name, $cap_value, $cap_line, $capVB, $capname, $capbins, $capsVB_vuln
 # Fat linpeas: 0
 # Small linpeas: 1
-
-
 if ! [ "$SEARCH_IN_FOLDER" ]; then
   print_2title "Capabilities"
   print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/index.html#capabilities"
   if [ "$(command -v capsh || echo -n '')" ]; then
-
     print_3title "Current shell capabilities"
     cat "/proc/$$/status" | grep Cap | while read -r cap_line; do
       cap_name=$(echo "$cap_line" | awk '{print $1}')
       cap_value=$(echo "$cap_line" | awk '{print $2}')
       if [ "$cap_name" = "CapEff:" ]; then
-        echo "$cap_name	 $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+        # Add validation check for cap_value
+        # For more POSIX-compliant formatting, the following could be used instead:
+        # if echo "$cap_value" | grep -E '^[0-9a-fA-F]+$' > /dev/null 2>&1; then
+        if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
+          # so we redirect stderr to prevent error propagation
+          echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+        else
+          echo "$cap_name	 [Invalid capability format]"
+        fi
       else
-        echo "$cap_name  $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED},")"
+        # Add validation check for cap_value
+        if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
+          # so we redirect stderr to prevent error propagation
+          echo "$cap_name  $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED},")"
+        else
+          echo "$cap_name  [Invalid capability format]"
+        fi
       fi
     done
     echo ""
-
     print_info "Parent process capabilities"
     cat "/proc/$PPID/status" | grep Cap | while read -r cap_line; do
       cap_name=$(echo "$cap_line" | awk '{print $1}')
       cap_value=$(echo "$cap_line" | awk '{print $2}')
       if [ "$cap_name" = "CapEff:" ]; then
-        echo "$cap_name	 $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+        # Add validation check for cap_value
+        if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
+          # so we redirect stderr to prevent error propagation
+          echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+        else
+          echo "$cap_name	 [Invalid capability format]"
+        fi
       else
-        echo "$cap_name	 $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED},")"
+        # Add validation check for cap_value
+        if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+          # Memory errors can occur with certain values (e.g., ffffffffffffffff)
+          # so we redirect stderr to prevent error propagation
+          echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED},")"
+        else
+          echo "$cap_name	 [Invalid capability format]"
+        fi
       fi
     done
     echo ""
@@ -69,7 +95,6 @@ if ! [ "$SEARCH_IN_FOLDER" ]; then
     if ! [ "$capsVB_vuln" ]; then
       echo "$cb" | sed -${E} "s,$capsB,${SED_RED},"
     fi
-
     if ! [ "$IAMROOT" ] && [ -w "$(echo $cb | cut -d" " -f1)" ]; then
       echo "$cb is writable" | sed -${E} "s,.*,${SED_RED},"
     fi


### PR DESCRIPTION
## Issue Description
The capabilities section of LINPEAS occasionally outputs long sequences of numbers when processing capability values. This occurs when the `capsh --decode` command encounters invalid input or errors, and the error output is then processed by subsequent commands.

## Steps Taken to Identify the Issue
1. Identified that the problem occurs in the capability decoding section
2. Created standalone test scripts to isolate and reproduce the issue
3. Determined that certain capability values (especially `ffffffffffffffff`) could cause `capsh --decode` to hang or output unexpected results
4. Confirmed that missing input validation was allowing invalid values to be passed to `capsh`

## Changes Made
1. Added regex validation to ensure `cap_value` contains only valid hexadecimal characters before processing
2. Added error redirection (`2>/dev/null`) to prevent error messages from being processed
3. Implemented fallback messaging when invalid capability formats are encountered

These changes maintain the original functionality while preventing the script from generating long sequences of numbers when processing capability data.




`# First section (current shell capabilities)
cat "/proc/$$/status" | grep Cap | while read -r cap_line; do
  cap_name=$(echo "$cap_line" | awk '{print $1}')
  cap_value=$(echo "$cap_line" | awk '{print $2}')
  if [ "$cap_name" = "CapEff:" ]; then
-    echo "$cap_name	 $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+    # Add validation check for cap_value
+    if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+      echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+    else
+      echo "$cap_name	 [Invalid capability format]"
+    fi
  else
-    echo "$cap_name  $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED},")"
+    # Add validation check for cap_value
+    if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+      echo "$cap_name  $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED},")"
+    else
+      echo "$cap_name  [Invalid capability format]"
+    fi
  fi
done

# Second section (parent process capabilities)
cat "/proc/$PPID/status" | grep Cap | while read -r cap_line; do
  cap_name=$(echo "$cap_line" | awk '{print $1}')
  cap_value=$(echo "$cap_line" | awk '{print $2}')
  if [ "$cap_name" = "CapEff:" ]; then
-    echo "$cap_name	 $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+    # Add validation check for cap_value
+    if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+      echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED_YELLOW},")"
+    else
+      echo "$cap_name	 [Invalid capability format]"
+    fi
  else
-    echo "$cap_name	 $(capsh --decode=0x"$cap_value" | sed -${E} "s,$capsB,${SED_RED},")"
+    # Add validation check for cap_value
+    if [[ "$cap_value" =~ ^[0-9a-fA-F]+$ ]]; then
+      echo "$cap_name	 $(capsh --decode=0x"$cap_value" 2>/dev/null | sed -${E} "s,$capsB,${SED_RED},")"
+    else
+      echo "$cap_name	 [Invalid capability format]"
+    fi
  fi
`done``